### PR TITLE
Expand Burning Chest Conjuring Ring to additional trader inventories

### DIFF
--- a/Burner/Public/Burner/Stats/Generated/TreasureTable.txt
+++ b/Burner/Public/Burner/Stats/Generated/TreasureTable.txt
@@ -1,7 +1,27 @@
+new treasuretable "BRN_OBJ_Burner_Chest_TT"
+new subtable "1,1"
+
+new treasuretable "TUT_Chest_Potions"
+CanMerge 1
+new subtable "1,1"
+object category "I_BRN_Ring_Conjure_Burner_Chest",1,0,0,0,0,0,0,0
+
 new treasuretable "DEN_Entrance_Trade"
 CanMerge 1
 new subtable "1,1"
 object category "I_BRN_Ring_Conjure_Burner_Chest",1,0,0,0,0,0,0,0
 
-new treasuretable "BRN_OBJ_Burner_Chest_TT"
+new treasuretable "GOB_Festivities_Trader"
+CanMerge 1
 new subtable "1,1"
+object category "I_BRN_Ring_Conjure_Burner_Chest",1,0,0,0,0,0,0,0
+
+new treasuretable "MOO_InfernalTrader_Trade"
+CanMerge 1
+new subtable "1,1"
+object category "I_BRN_Ring_Conjure_Burner_Chest",1,0,0,0,0,0,0,0
+
+new treasuretable "HAV_HarperQuarterMaster"
+CanMerge 1
+new subtable "1,1"
+object category "I_BRN_Ring_Conjure_Burner_Chest",1,0,0,0,0,0,0,0

--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ There may be a number of reasons to do this.  For example, you might want to eli
 
 ## Mod Usage
 
-1. Purchase the "Burner Chest Conjuring Ring" from the merchant, [Arron](https://bg3.wiki/wiki/Arron).
+1. Obtain the "Burner Chest Conjuring Ring" from one of the following locations:
+    - [Cartilaginous Chest](https://bg3.wiki/wiki/Cartilaginous_Chest) - in the Nautiloid tutorial area
+    - [Arron](https://bg3.wiki/wiki/Arron) - a merchant in Druid Grove
+    - [Grat](https://bg3.wiki/wiki/Grat) - a Goblin Camp festitivites merchant
+    - [Araj Oblodra](https://bg3.wiki/wiki/Araj_Oblodra) - a Moonrise Tower merchant
+    - [Quartermaster Talli](https://bg3.wiki/wiki/Talli) - a Last Light Inn merchant
 2. Equip the ring.
 3. Click the new "Conjure Burner Chest" spell and target the location where you want to place the Chest on the ground. Use the spell.
 4. Open the chest and deposit all unwanted equipment.


### PR DESCRIPTION
Closes #6 

Adds the Burner Chest Conjuring Ring to several new merchant inventories:

- Tutorial potion chest
- Grat, the goblin camp merchant
- Araj Oblodra, the Moonrise Tower merchant
- Quartermaster Talli, the Last Light Inn merchant